### PR TITLE
Feature: Global Workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "cc"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "libc",
 ]
@@ -95,9 +95,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -400,18 +400,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.182"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb30a74471f5b7a1fa299f40b4bf1be93af61116df95465b2b5fc419331e430"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.182"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4c2c6ea4bc09b5c419012eafcdb0fcef1d9119d626c8f3a0708a5b92d38a70"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -528,7 +528,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vgtd"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +222,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -301,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +356,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -343,11 +381,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -481,6 +539,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +611,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
+ "directories",
  "lazy_static",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vgtd"
 description = "Volatus' GTD utility tool"
 authors = ["Volatus"]
-version = "1.0.0"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/veritatislux/vgtd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ regex = "1.8"
 toml = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 colored = "2.0"
+directories = "5"
 
 [profile.dev]
 opt-level = 0

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -64,7 +64,7 @@ pub fn initialize_workspace(path: &str) -> EResult<()>
 
     write_workspace_defaults(path)?;
 
-    tos::send_success("New workspace initialized in this directory.");
+    tos::send_success("New workspace initialized in the target directory.");
 
     Ok(())
 }
@@ -570,14 +570,14 @@ pub fn show_all_lists(file: &mut File) -> EResult<()>
 {
     if file.lists().is_empty()
     {
-        tos::send_info(&format!("There are no lists in this workspace."));
+        tos::send_info(&format!("There are no lists in the workspace."));
         return Ok(());
     }
 
     let mut output = tos::OutputBlock::new();
 
     output
-        .insert_line("Lists in the current workspace", 0)
+        .insert_line("Lists in the workspace", 0)
         .insert_text("\n");
 
     for list in file.lists.iter()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,9 +20,7 @@ use crate::gtd::ListContainer;
 use crate::gtd::ProjectContainer;
 use crate::gtd::TaskContainer;
 
-pub const GTD_FILE_PATH: &str = ".gtd.toml";
-
-pub fn write_workspace_defaults() -> EResult<()>
+pub fn write_workspace_defaults(path: &str) -> EResult<()>
 {
     let basic_structure = File {
         lists: vec![
@@ -32,14 +30,14 @@ pub fn write_workspace_defaults() -> EResult<()>
         ],
     };
 
-    basic_structure.write_to_file(GTD_FILE_PATH)?;
+    basic_structure.write_to_file(path)?;
 
     Ok(())
 }
 
-pub fn reset_workspace() -> EResult<()>
+pub fn reset_workspace(path: &str) -> EResult<()>
 {
-    if !path::Path::new(GTD_FILE_PATH).exists()
+    if !path::Path::new(path).exists()
     {
         return Err(Box::new(io::Error::new(
             ErrorKind::NotFound,
@@ -47,16 +45,16 @@ pub fn reset_workspace() -> EResult<()>
         )));
     }
 
-    write_workspace_defaults()?;
+    write_workspace_defaults(path)?;
 
     tos::send_success("The workspace has been reset.");
 
     Ok(())
 }
 
-pub fn initialize_workspace() -> EResult<()>
+pub fn initialize_workspace(path: &str) -> EResult<()>
 {
-    if path::Path::new(GTD_FILE_PATH).exists()
+    if path::Path::new(path).exists()
     {
         return Err(Box::new(io::Error::new(
             ErrorKind::AlreadyExists,
@@ -64,7 +62,7 @@ pub fn initialize_workspace() -> EResult<()>
         )));
     }
 
-    write_workspace_defaults()?;
+    write_workspace_defaults(path)?;
 
     tos::send_success("New workspace initialized in this directory.");
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -338,7 +338,7 @@ pub fn show_list(file: &mut File, name: &str, all: bool) -> EResult<()>
 
     if list.tasks().is_empty() && list.projects().is_empty()
     {
-        tos::send_success(&format!("List {formatted_name} is empty."));
+        tos::send_info(&format!("List {formatted_name} is empty."));
 
         return Ok(());
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -471,6 +471,16 @@ pub fn show_project(file: &mut File, path: &str) -> EResult<()>
 
     let project = list.get_project_forced(project_index)?;
 
+    if project.tasks().is_empty()
+    {
+        tos::send_info(&format!(
+            "Project {} is empty.",
+            tos::format_project_name(&project.name, &project.status())
+        ));
+
+        return Ok(());
+    }
+
     let mut output = tos::OutputBlock::new();
 
     output

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,0 +1,36 @@
+use std::io;
+
+use crate::EResult;
+
+pub const GTD_FILE_PATH: &str = ".gtd.toml";
+
+pub fn get_workspace_file_path(global: bool) -> EResult<String>
+{
+    if !global
+    {
+        return Ok(GTD_FILE_PATH.to_owned());
+    }
+
+    if let Some(base_dir) = directories::BaseDirs::new()
+    {
+        if let Some(path_str) =
+            base_dir.home_dir().join(GTD_FILE_PATH).to_str()
+        {
+            Ok(path_str.to_owned())
+        }
+        else
+        {
+            return Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unable to parse global workspace path.",
+            )));
+        }
+    }
+    else
+    {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Could not locate global workspace file path.",
+        )));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod dirs;
 mod file;
 mod gtd;
 mod indexer;
@@ -11,8 +12,6 @@ use std::error::Error;
 use clap::Parser;
 use clap::Subcommand;
 use gtd::Status;
-
-use crate::commands::GTD_FILE_PATH;
 
 pub type EResult<T> = Result<T, Box<dyn Error>>;
 
@@ -157,23 +156,29 @@ pub struct Args
 {
     #[command(subcommand)]
     sub: GTDSubcommand,
+
+    /// If provided, initialize the global workspace
+    #[arg(long, short)]
+    global: bool,
 }
 
 pub fn parse_cli_arguments() -> EResult<()>
 {
     let args = Args::parse();
 
+    let file_path = dirs::get_workspace_file_path(args.global)?;
+
     if let GTDSubcommand::Init = args.sub
     {
-        return commands::initialize_workspace();
+        return commands::initialize_workspace(&file_path);
     }
 
     if let GTDSubcommand::Reset = args.sub
     {
-        return commands::reset_workspace();
+        return commands::reset_workspace(&file_path);
     }
 
-    let mut file = file::parse(GTD_FILE_PATH)?;
+    let mut file = file::parse(&file_path)?;
 
     match args.sub
     {
@@ -252,5 +257,5 @@ pub fn parse_cli_arguments() -> EResult<()>
         {}
     };
 
-    file.write_to_file(GTD_FILE_PATH)
+    file.write_to_file(&file_path)
 }


### PR DESCRIPTION
Users are now able to append the `--global` (or its shortform `-g`) flag to the root command before the subcommands in order to target the Global Workspace File instead of the Local Workspace File. We are now depending on the [directories](https://docs.rs/directories/5.0.1/directories/index.html) crate to make our program cross platform, and the location of the Global Workspace File relies on the [`BaseDirs::home_dir`](https://docs.rs/directories/5.0.1/directories/struct.BaseDirs.html#method.home_dir) function, in which the `.gtd.toml` file is searched for.

At the time of writing, these are:
| Platform | Path |
|-|-|
| Linux | `$HOME/.gtd.toml` |
| macOS | `$HOME/.gtd.toml` |
| Windows | `{FOLDERID_Profile}` (Usually `C:\Users\<user>\.gtd.toml`) |